### PR TITLE
Fix JSError  on skuber 2.0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ status:
     resourceRequests:
       cpu: false
       memory: false
-  used: {}
+  used: 
+    resourceRequests: {}
 ```
 
 Then, create a pods with label `throttle=t1` and `requests` `cpu=300m`.
@@ -278,7 +279,7 @@ $ kubectl create -f example/pod3.yaml
 $ kubectl get po pod3
 NAME   READY   STATUS    RESTARTS   AGE
 pod3   0/1     Pending   0          5s
-$ kubectl describe pod3
+$ kubectl describe pod pod3
 ...
 Events:
   Type     Reason            Age               From          Message

--- a/src/main/scala/com/github/everpeace/k8s/Skuber2_0_12_Fix.scala
+++ b/src/main/scala/com/github/everpeace/k8s/Skuber2_0_12_Fix.scala
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2018 Shingo Omura <https://github.com/everpeace>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.everpeace.k8s
+import skuber.Pod
+import skuber.Pod.Affinity.MatchExpression
+import com.typesafe.scalalogging.StrictLogging
+
+// FIXME
+object Skuber2_0_12_Fix extends StrictLogging {
+  import play.api.libs.functional.syntax._
+  import play.api.libs.json._
+  import skuber.Pod.Affinity.NodeSelectorTerm
+
+  implicit val fixedNodeRequiredDuringSchedulingIgnoredDuringExecutionFormat
+    : Format[Pod.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution] = {
+
+    // THIS IS THE ROOT CAUSE
+    // ref: https://github.com/doriordan/skuber/pull/246
+    implicit val fixedNodeSelectorTermFormat: Format[NodeSelectorTerm] = {
+      import skuber.json.format.{maybeEmptyFormatMethods, nodeMatchExpressionFormat}
+      ((JsPath \ "matchExpressions")
+        .formatMaybeEmptyList[MatchExpression] and (JsPath \ "matchFields")
+        .formatNullable[List[MatchExpression]])(
+        (matchExpressions, matchFieldsOpt) => {
+          matchFieldsOpt foreach { matchFields =>
+            logger.error(
+              s"'matchFields' field detected!! it will be ignored for unmarshaling due to the issue (skuber#246). content = ${Json
+                .stringify(Json.toJson(matchFields))}")
+          }
+          Pod.Affinity.NodeSelectorTerm(matchExpressions)
+        },
+        nst => (nst.matchExpressions, None)
+      )
+    }
+
+    (JsPath \ "nodeSelectorTerms")
+      .format[Pod.Affinity.NodeSelectorTerms]
+      .inmap(
+        nodeSelectorTerms =>
+          Pod.Affinity.NodeAffinity
+            .RequiredDuringSchedulingIgnoredDuringExecution(nodeSelectorTerms),
+        (rdside: Pod.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution) =>
+          rdside.nodeSelectorTerms
+      )
+  }
+
+  implicit val fixedNodeAffinityFormat: Format[Pod.Affinity.NodeAffinity] = {
+    import skuber._
+    import skuber.json.format.{maybeEmptyFormatMethods, nodePreferredSchedulingTermFormat}
+
+    ((JsPath \ "requiredDuringSchedulingIgnoredDuringExecution")
+      .formatNullable[Pod.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution](
+        fixedNodeRequiredDuringSchedulingIgnoredDuringExecutionFormat) and
+      (JsPath \ "preferredDuringSchedulingIgnoredDuringExecution")
+        .formatMaybeEmptyList[Pod.Affinity.NodeAffinity.PreferredSchedulingTerm])(
+      Pod.Affinity.NodeAffinity.apply _,
+      unlift(Pod.Affinity.NodeAffinity.unapply))
+  }
+
+  implicit val fixedPodAffinityFormat: Format[Pod.Affinity] = {
+    import skuber.json.format.{podAffinityFormat, podAntiAffinityFormat}
+
+    Json.format[Pod.Affinity]
+  }
+
+  implicit val fixedPodSpecFormat: Format[Pod.Spec] = {
+    import skuber._
+    import skuber.json.format.{affinityFormat => _, _}
+
+    val podSpecPartOneFormat: OFormat[
+      (List[Container],
+       List[Container],
+       List[Volume],
+       skuber.RestartPolicy.Value,
+       Option[Int],
+       Option[Int],
+       skuber.DNSPolicy.Value,
+       Map[String, String],
+       String,
+       String,
+       Boolean,
+       List[LocalObjectReference],
+       Option[Pod.Affinity],
+       List[Pod.Toleration],
+       Option[Security.Context])] = (
+      (JsPath \ "containers").format[List[Container]] and
+        (JsPath \ "initContainers").formatMaybeEmptyList[Container] and
+        (JsPath \ "volumes").formatMaybeEmptyList[Volume] and
+        (JsPath \ "restartPolicy").formatEnum(RestartPolicy, Some(RestartPolicy.Always)) and
+        (JsPath \ "terminationGracePeriodSeconds").formatNullable[Int] and
+        (JsPath \ "activeDeadlineSeconds").formatNullable[Int] and
+        (JsPath \ "dnsPolicy").formatEnum(DNSPolicy, Some(DNSPolicy.ClusterFirst)) and
+        (JsPath \ "nodeSelector").formatMaybeEmptyMap[String] and
+        (JsPath \ "serviceAccountName").formatMaybeEmptyString() and
+        (JsPath \ "nodeName").formatMaybeEmptyString() and
+        (JsPath \ "hostNetwork").formatMaybeEmptyBoolean() and
+        (JsPath \ "imagePullSecrets").formatMaybeEmptyList[LocalObjectReference] and
+        (JsPath \ "affinity").formatNullable[Pod.Affinity](fixedPodAffinityFormat) and
+        (JsPath \ "tolerations").formatMaybeEmptyList[Pod.Toleration] and
+        (JsPath \ "securityContext").formatNullable[Security.Context]
+    ).tupled
+
+    (podSpecPartOneFormat and podSpecPartTwoFormat).apply(
+      {
+        case ((conts,
+               initConts,
+               vols,
+               rpol,
+               tgps,
+               adls,
+               dnspol,
+               nodesel,
+               svcac,
+               node,
+               hnet,
+               ips,
+               aff,
+               tol,
+               sc),
+              (host, aliases, pid, ipc, asat, prio, prioc, sched, subd, dnsc)) =>
+          Pod.Spec(conts,
+                   initConts,
+                   vols,
+                   rpol,
+                   tgps,
+                   adls,
+                   dnspol,
+                   nodesel,
+                   svcac,
+                   node,
+                   hnet,
+                   ips,
+                   aff,
+                   tol,
+                   sc,
+                   host,
+                   aliases,
+                   pid,
+                   ipc,
+                   asat,
+                   prio,
+                   prioc,
+                   sched,
+                   subd,
+                   dnsc)
+      },
+      s =>
+        ((s.containers,
+          s.initContainers,
+          s.volumes,
+          s.restartPolicy,
+          s.terminationGracePeriodSeconds,
+          s.activeDeadlineSeconds,
+          s.dnsPolicy,
+          s.nodeSelector,
+          s.serviceAccountName,
+          s.nodeName,
+          s.hostNetwork,
+          s.imagePullSecrets,
+          s.affinity,
+          s.tolerations,
+          s.securityContext),
+         (s.hostname,
+          s.hostAliases,
+          s.hostPID,
+          s.hostIPC,
+          s.automountServiceAccountToken,
+          s.priority,
+          s.priorityClassName,
+          s.schedulerName,
+          s.subdomain,
+          s.dnsConfig))
+    )
+  }
+
+  implicit val fixedPodFormat: Format[Pod] = {
+    import skuber._
+    import skuber.json.format.{objFormat, podStatusFormat}
+    (objFormat and
+      (JsPath \ "spec").formatNullable[Pod.Spec](fixedPodSpecFormat) and
+      (JsPath \ "status").formatNullable[Pod.Status])(Pod.apply _, unlift(Pod.unapply))
+  }
+}

--- a/src/main/scala/com/github/everpeace/k8s/throttler/crd/v1alpha1/ClusterThrottle.scala
+++ b/src/main/scala/com/github/everpeace/k8s/throttler/crd/v1alpha1/ClusterThrottle.scala
@@ -44,7 +44,7 @@ object ClusterThrottle {
   trait JsonFormats extends CommonJsonFormat {
     import play.api.libs.functional.syntax._
     import play.api.libs.json._
-    import skuber.json.format._
+    import skuber.json.format.{maybeEmptyFormatMethods, jsPath2LabelSelFormat}
 
     implicit val clusterThrottleSpecFmt: Format[v1alpha1.ClusterThrottle.Spec] = (
       (JsPath \ "throttlerName").formatMaybeEmptyString(true) and

--- a/src/main/scala/com/github/everpeace/k8s/throttler/crd/v1alpha1/Throttle.scala
+++ b/src/main/scala/com/github/everpeace/k8s/throttler/crd/v1alpha1/Throttle.scala
@@ -45,7 +45,7 @@ object Throttle {
   trait JsonFormat extends CommonJsonFormat {
     import play.api.libs.functional.syntax._
     import play.api.libs.json._
-    import skuber.json.format._
+    import skuber.json.format.{maybeEmptyFormatMethods, jsPath2LabelSelFormat}
 
     implicit val throttleSpecFmt: Format[v1alpha1.Throttle.Spec] = (
       (JsPath \ "throttlerName").formatMaybeEmptyString(true) and

--- a/src/main/scala/com/github/everpeace/k8s/throttler/crd/v1alpha1/package.scala
+++ b/src/main/scala/com/github/everpeace/k8s/throttler/crd/v1alpha1/package.scala
@@ -22,7 +22,6 @@ import com.github.everpeace.util.Injection.{==>, _}
 import com.github.everpeace.util.Isomorphism.<=>
 import skuber.Resource.ResourceList
 import skuber.{CustomResource, ListResource, Pod}
-import skuber.json.format._
 
 package object v1alpha1 {
   type Throttle     = CustomResource[v1alpha1.Throttle.Spec, v1alpha1.Throttle.Status]
@@ -46,6 +45,7 @@ package object v1alpha1 {
 
   trait CommonJsonFormat {
     import play.api.libs.json._
+    import skuber.json.format.quantityFormat
 
     implicit val resourceCountsFmt: Format[v1alpha1.ResourceCount] =
       Json.format[v1alpha1.ResourceCount]

--- a/src/main/scala/com/github/everpeace/k8s/throttler/crd/v1alpha1/package.scala
+++ b/src/main/scala/com/github/everpeace/k8s/throttler/crd/v1alpha1/package.scala
@@ -19,7 +19,6 @@ package com.github.everpeace.k8s.throttler.crd
 import cats.syntax.order._
 import com.github.everpeace.k8s._
 import com.github.everpeace.util.Injection.{==>, _}
-import com.github.everpeace.util.Isomorphism.<=>
 import skuber.Resource.ResourceList
 import skuber.{CustomResource, ListResource, Pod}
 

--- a/src/main/scala/io/k8s/pkg/scheduler/api/v1/package.scala
+++ b/src/main/scala/io/k8s/pkg/scheduler/api/v1/package.scala
@@ -18,7 +18,7 @@ package io.k8s.pkg.scheduler.api
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import skuber.json.format._
+import skuber.json.format.{podSpecFmt => _, _}
 import skuber.{ListMeta, ListResource, Node, NodeList, ObjectMeta, Pod}
 
 // ref: https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/api/v1/types.go
@@ -33,12 +33,12 @@ package object v1 {
       error: Option[String] = None)
 
   object Implicits {
-
+    import com.github.everpeace.k8s.Skuber2_0_12_Fix
     // kube-scheduler doesn't send 'apiVersion' and 'kind' attributes
     // on Pod, Node, NodeList
     implicit val podFormat: Format[Pod] = (
       (JsPath \ "metadata").lazyFormat[ObjectMeta](objectMetaFormat) and
-        (JsPath \ "spec").formatNullable[Pod.Spec] and
+        (JsPath \ "spec").formatNullable[Pod.Spec](Skuber2_0_12_Fix.fixedPodSpecFormat) and
         (JsPath \ "status").formatNullable[Pod.Status]
     )(
       Pod("Pod", "v1", _, _, _),

--- a/src/test/scala/com/github/everpeace/k8s/Skuber2_0_12_FixSpec.scala
+++ b/src/test/scala/com/github/everpeace/k8s/Skuber2_0_12_FixSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Shingo Omura <https://github.com/everpeace>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.everpeace.k8s
+
+import org.scalatest.{FreeSpec, Matchers}
+import play.api.libs.json._
+import skuber._
+import Pod.Affinity._
+import NodeAffinity.{RequiredDuringSchedulingIgnoredDuringExecution => Required}
+
+class Skuber2_0_12_FixSpec extends FreeSpec with Matchers {
+
+  "FixedNodeSelectorTermFormat" - {
+    import Skuber2_0_12_Fix.fixedNodeRequiredDuringSchedulingIgnoredDuringExecutionFormat
+
+    "can parse it only with matchFields but it is skipped" in {
+      val termJson = Json.parse(
+        """
+          |{
+          |  "nodeSelectorTerms": [{
+          |    "matchFields": [{
+          |       "key": "some-key",
+          |       "operator": "In",
+          |       "values": ["some-value"]
+          |    }]
+          |  }]
+          |}
+        """.stripMargin
+      )
+      val myTerm = Json.fromJson[Required](termJson).get
+      val term   = Required(nodeSelectorTerms = List(NodeSelectorTerm(List.empty)))
+      myTerm shouldBe term
+    }
+
+    "can parse it only with matchExpressions" in {
+      val termJson = Json.parse(
+        """
+          |{
+          |  "nodeSelectorTerms": [{
+          |    "matchExpressions": [{
+          |       "key": "some-key",
+          |       "operator": "In",
+          |      "values": ["some-value"]
+          |    }]
+          |  }]
+          |}
+        """.stripMargin
+      )
+      val myTerm = Json.fromJson[Required](termJson).get
+      val term = Required(
+        nodeSelectorTerms = List(
+          NodeSelectorTerm(
+            MatchExpressions(
+              MatchExpression("some-key", NodeSelectorOperator.In, List("some-value"))
+            )))
+      )
+      myTerm shouldBe term
+    }
+
+    "can parse it with both matchExpressions and matchFields, but matchFields are ignored" in {
+      val termJson = Json.parse(
+        """
+          |{
+          |  "nodeSelectorTerms": [{
+          |    "matchExpressions": [{
+          |       "key": "some-key",
+          |       "operator": "In",
+          |       "values": ["some-value"]
+          |    }],
+          |    "matchFields": [{
+          |       "key": "some-key",
+          |       "operator": "In",
+          |       "values": ["some-value"]
+          |    }]
+          |  }]
+          |}
+        """.stripMargin
+      )
+      val myTerm = Json.fromJson[Required](termJson).get
+      val term = Required(
+        nodeSelectorTerms = List(
+          NodeSelectorTerm(
+            MatchExpressions(
+              MatchExpression("some-key", NodeSelectorOperator.In, List("some-value"))
+            )))
+      )
+      myTerm shouldBe term
+    }
+  }
+}


### PR DESCRIPTION
ref: https://github.com/doriordan/skuber/pull/246

As a workaround until the issue will be fixed, I made another `Fromat[Pod]` which skip `matchFields` attribute.