### PR TITLE
support OR-ed selector, namespaceSelector support in ClusterThrottle

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,14 @@ metadata:
 spec:
   # throttler name which responsible for this Throttle custom resource
   throttlerName: kube-throttler
-  # you can write any label selector freely 
+  # you can write any label selector freely
+  # items under selecterTerms are evaluated OR-ed
+  # each selecterTerm item are evaluated AND-ed 
   selector:
-    matchLabels:
-      throttle: t1
+    selecterTerms:
+    - podSelector:
+        matchLabels:
+          throttle: t1
   # you can set a threshold of the throttle
   threshold:
     # limiting total count of resources
@@ -144,8 +148,10 @@ $ kubectl get throttle t1 -o yaml
 spec:
   throttlerName: kube-throttler
   selector:
-    matchLabels:
-      throttle: t1
+    selecterTerms:
+    - podSelector:
+        matchLabels:
+          throttle: t1
   threshold:
     resourceCounts:
       pod: 5
@@ -249,8 +255,10 @@ $ kubectl get throttle t1 -o yaml
 ...
 spec:
   selector:
-    matchLabels:
-      throttle: t1
+    selecterTerms:
+    - podSelector:
+        matchLabels:
+          throttle: t1
   threshold:
     resourceCounts:
       pod: 5

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val root = (project in file("."))
     dockerUsername := Some("everpeace"),
     packageName in Docker := "kube-throttler",
     maintainer in Docker := "Shingo Omura <https://github.com/everpeace>",
-    dockerBaseImage := "frolvlad/alpine-oraclejdk8:8.181.13-slim",
+    dockerBaseImage := "adoptopenjdk/openjdk8:x86_64-alpine-jdk8u191-b12",
     dockerExposedPorts := Seq(
       4321 /* kube-throttle (kube-scheduler extender) */,
       5005 /* for jvm debug */,

--- a/deploy/0-crd.yaml
+++ b/deploy/0-crd.yaml
@@ -30,6 +30,16 @@ spec:
           properties:
             selector:
               type: object
+              required:
+                - selectorTerms
+              properties:
+                selectorTerms:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      podSelector:
+                        type: object
             threshold:
               type: object
               properties:
@@ -73,6 +83,18 @@ spec:
           properties:
             selector:
               type: object
+              required:
+              - selectorTerms
+              properties:
+                selectorTerms:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      namespaceSelector:
+                        type: object
+                      podSelector:
+                        type: object
             threshold:
               type: object
               properties:

--- a/deploy/2-rbac.yaml
+++ b/deploy/2-rbac.yaml
@@ -10,7 +10,7 @@ metadata:
   name: kube-throttler
 rules:
 - apiGroups: [""]
-  resources: ["pods"]
+  resources: ["pods", "namespaces"]
   verbs: ["get","list","watch"]
 - apiGroups: ["schedule.k8s.everpeace.github.com"]
   resources: ["clusterthrottles"]

--- a/example/clthrottle.yaml
+++ b/example/clthrottle.yaml
@@ -5,8 +5,13 @@ metadata:
 spec:
   throttlerName: kube-throttler
   selector:
-    matchLabels:
-      throttle: t1
+    selectorTerms:
+    - namespaceSelector:
+        matchLabels:
+          throttle: 'true'
+      podSelector:
+        matchLabels:
+          throttle: t1
   threshold:
     resourceCounts:
       pod: 5

--- a/example/throttle.yaml
+++ b/example/throttle.yaml
@@ -5,8 +5,10 @@ metadata:
 spec:
   throttlerName: kube-throttler
   selector:
-    matchLabels:
-      throttle: t1
+    selectorTerms:
+    - podSelector:
+        matchLabels:
+          throttle: t1
   threshold:
     resourceCounts:
       pod: 5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += Resolver.bintrayRepo("kamon-io", "sbt-plugins")
 addSbtPlugin("com.lucidchart"    % "sbt-scalafmt" % "1.15")
 addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.9")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.6")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.15")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
 addSbtPlugin("io.kamon" % "sbt-aspectj-runner" % "1.1.0")
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")

--- a/src/main/scala/com/github/everpeace/k8s/throttler/controller/ThrottleControllerLogic.scala
+++ b/src/main/scala/com/github/everpeace/k8s/throttler/controller/ThrottleControllerLogic.scala
@@ -38,7 +38,7 @@ trait ThrottleControllerLogic {
     for {
       throttle <- targetThrottles.toList
 
-      matchedPods = podsInNs.filter(p => throttle.spec.selector.matches(p.metadata.labels))
+      matchedPods = podsInNs.filter(pod => throttle.spec.selector.matches(pod))
       runningPods = matchedPods
         .filter(p => p.status.exists(_.phase.exists(_ == Pod.Phase.Running)))
         .toList

--- a/src/test/scala/com/github/everpeace/k8s/throttler/RoutesSpec.scala
+++ b/src/test/scala/com/github/everpeace/k8s/throttler/RoutesSpec.scala
@@ -40,7 +40,10 @@ class RoutesSpec extends FreeSpec with Matchers with ScalatestRouteTest with Pla
         "throttle",
         v1alpha1.Throttle.Spec(
           throttlerName = "kube-throttler",
-          selector = LabelSelector(),
+          selector = v1alpha1.Throttle.Selector(
+            List(
+              v1alpha1.Throttle.SelectorItem(LabelSelector())
+            )),
           threshold = ResourceAmount(
             resourceRequests = Map("cpu" -> Quantity("1"))
           )
@@ -64,7 +67,10 @@ class RoutesSpec extends FreeSpec with Matchers with ScalatestRouteTest with Pla
         "nospacethrottle",
         v1alpha1.Throttle.Spec(
           throttlerName = "kube-throttler",
-          selector = LabelSelector(),
+          selector = v1alpha1.Throttle.Selector(
+            List(
+              v1alpha1.Throttle.SelectorItem(LabelSelector())
+            )),
           threshold = ResourceAmount(
             resourceRequests = Map("cpu" -> Quantity("1"))
           )
@@ -79,7 +85,10 @@ class RoutesSpec extends FreeSpec with Matchers with ScalatestRouteTest with Pla
         "clusterthrottle",
         v1alpha1.ClusterThrottle.Spec(
           throttlerName = "kube-throttler",
-          selector = LabelSelector(),
+          selector = v1alpha1.ClusterThrottle.Selector(
+            List(
+              v1alpha1.ClusterThrottle.SelectorItem(LabelSelector())
+            )),
           threshold = ResourceAmount(
             resourceRequests = Map("cpu" -> Quantity("1"))
           )
@@ -102,7 +111,10 @@ class RoutesSpec extends FreeSpec with Matchers with ScalatestRouteTest with Pla
         "nospacethrottle",
         v1alpha1.ClusterThrottle.Spec(
           throttlerName = "kube-throttler",
-          selector = LabelSelector(),
+          selector = v1alpha1.ClusterThrottle.Selector(
+            List(
+              v1alpha1.ClusterThrottle.SelectorItem(LabelSelector())
+            )),
           threshold = ResourceAmount(
             resourceRequests = Map("cpu" -> Quantity("1"))
           )

--- a/src/test/scala/com/github/everpeace/k8s/throttler/controller/ThrottleControllerLogicSpec.scala
+++ b/src/test/scala/com/github/everpeace/k8s/throttler/controller/ThrottleControllerLogicSpec.scala
@@ -63,7 +63,9 @@ class ThrottleControllerLogicSpec extends FreeSpec with Matchers with ThrottleCo
             "t1",
             v1alpha1.Throttle.Spec(
               throttlerName = "kube-throttler",
-              selector = LabelSelector(IsEqualRequirement("key", "value")),
+              selector = v1alpha1.Throttle.Selector(List(
+                v1alpha1.Throttle.SelectorItem(LabelSelector(IsEqualRequirement("key", "value")))
+              )),
               // throttle is defined on "r" and "s"
               threshold = ResourceAmount(
                 resourceRequests = Map("r" -> Quantity("2"), "s" -> Quantity("3"))
@@ -111,7 +113,9 @@ class ThrottleControllerLogicSpec extends FreeSpec with Matchers with ThrottleCo
             "t1",
             v1alpha1.Throttle.Spec(
               throttlerName = "kube-throttler",
-              selector = LabelSelector(IsEqualRequirement("key", "value")),
+              selector = v1alpha1.Throttle.Selector(List(
+                v1alpha1.Throttle.SelectorItem(LabelSelector(IsEqualRequirement("key", "value")))
+              )),
               threshold = ResourceAmount(
                 resourceCounts = Option(
                   ResourceCount(
@@ -158,7 +162,10 @@ class ThrottleControllerLogicSpec extends FreeSpec with Matchers with ThrottleCo
             "t1",
             v1alpha1.Throttle.Spec(
               throttlerName = "kube-throttler",
-              selector = LabelSelector(IsEqualRequirement("key", "value")),
+              selector = v1alpha1.Throttle.Selector(
+                List(
+                  v1alpha1.Throttle.SelectorItem(LabelSelector(IsEqualRequirement("key", "value")))
+                )),
               // throttle is defined on "r" and "s"
               threshold = ResourceAmount(
                 resourceRequests = Map("r" -> Quantity("3"), "s" -> Quantity("2"))
@@ -247,7 +254,9 @@ class ThrottleControllerLogicSpec extends FreeSpec with Matchers with ThrottleCo
             "t1",
             v1alpha1.Throttle.Spec(
               throttlerName = "kube-throttler",
-              selector = LabelSelector(IsEqualRequirement("key", "value")),
+              selector = v1alpha1.Throttle.Selector(List(
+                v1alpha1.Throttle.SelectorItem(LabelSelector(IsEqualRequirement("key", "value")))
+              )),
               threshold = ResourceAmount(
                 resourceCounts = Option(
                   ResourceCount(
@@ -290,7 +299,9 @@ class ThrottleControllerLogicSpec extends FreeSpec with Matchers with ThrottleCo
             "t1",
             v1alpha1.Throttle.Spec(
               throttlerName = "kube-throttler",
-              selector = LabelSelector(IsEqualRequirement("key", "value")),
+              selector = v1alpha1.Throttle.Selector(List(
+                v1alpha1.Throttle.SelectorItem(LabelSelector(IsEqualRequirement("key", "value")))
+              )),
               threshold = ResourceAmount(
                 resourceCounts = Option(ResourceCount(
                   pod = Option(2)
@@ -330,7 +341,10 @@ class ThrottleControllerLogicSpec extends FreeSpec with Matchers with ThrottleCo
             "t1",
             v1alpha1.Throttle.Spec(
               throttlerName = "kube-throttler",
-              selector = LabelSelector(IsEqualRequirement("key", "value")),
+              selector = v1alpha1.Throttle.Selector(
+                List(
+                  v1alpha1.Throttle.SelectorItem(LabelSelector(IsEqualRequirement("key", "value")))
+                )),
               threshold = ResourceAmount(
                 resourceRequests = Map("s" -> Quantity("3"))
               )
@@ -368,7 +382,10 @@ class ThrottleControllerLogicSpec extends FreeSpec with Matchers with ThrottleCo
             "t1",
             v1alpha1.Throttle.Spec(
               throttlerName = "kube-throttler",
-              selector = LabelSelector(IsEqualRequirement("key", "value")),
+              selector = v1alpha1.Throttle.Selector(
+                List(
+                  v1alpha1.Throttle.SelectorItem(LabelSelector(IsEqualRequirement("key", "value")))
+                )),
               threshold = ResourceAmount(
                 resourceRequests = Map("r" -> Quantity("2"), "s" -> Quantity("3"))
               )
@@ -406,7 +423,10 @@ class ThrottleControllerLogicSpec extends FreeSpec with Matchers with ThrottleCo
             "t1",
             v1alpha1.Throttle.Spec(
               throttlerName = "kube-throttler",
-              selector = LabelSelector(IsEqualRequirement("key", "value")),
+              selector = v1alpha1.Throttle.Selector(
+                List(
+                  v1alpha1.Throttle.SelectorItem(LabelSelector(IsEqualRequirement("key", "value")))
+                )),
               threshold = ResourceAmount(
                 resourceRequests = Map("r" -> Quantity("1"))
               )
@@ -444,7 +464,10 @@ class ThrottleControllerLogicSpec extends FreeSpec with Matchers with ThrottleCo
             "t1",
             v1alpha1.Throttle.Spec(
               throttlerName = "kube-throttler",
-              selector = LabelSelector(IsEqualRequirement("key", "value")),
+              selector = v1alpha1.Throttle.Selector(
+                List(
+                  v1alpha1.Throttle.SelectorItem(LabelSelector(IsEqualRequirement("key", "value")))
+                )),
               threshold = ResourceAmount(
                 resourceRequests = Map("r" -> Quantity("3"))
               )
@@ -482,7 +505,10 @@ class ThrottleControllerLogicSpec extends FreeSpec with Matchers with ThrottleCo
             "t1",
             v1alpha1.Throttle.Spec(
               throttlerName = "kube-throttler",
-              selector = LabelSelector(IsEqualRequirement("key", "value")),
+              selector = v1alpha1.Throttle.Selector(
+                List(
+                  v1alpha1.Throttle.SelectorItem(LabelSelector(IsEqualRequirement("key", "value")))
+                )),
               threshold = ResourceAmount(
                 resourceCounts = Option(
                   ResourceCount(
@@ -529,7 +555,10 @@ class ThrottleControllerLogicSpec extends FreeSpec with Matchers with ThrottleCo
             "t1",
             v1alpha1.Throttle.Spec(
               throttlerName = "kube-throttler",
-              selector = LabelSelector(IsEqualRequirement("key", "value")),
+              selector = v1alpha1.Throttle.Selector(
+                List(
+                  v1alpha1.Throttle.SelectorItem(LabelSelector(IsEqualRequirement("key", "value")))
+                )),
               threshold = ResourceAmount(
                 resourceCounts = Option(ResourceCount(
                   pod = Option(2)

--- a/src/test/scala/com/github/everpeace/k8s/throttler/crd/ClusterThrottleFormatSpec.scala
+++ b/src/test/scala/com/github/everpeace/k8s/throttler/crd/ClusterThrottleFormatSpec.scala
@@ -16,6 +16,7 @@
 
 package com.github.everpeace.k8s.throttler.crd
 
+import com.github.everpeace.k8s.throttler.crd.v1alpha1.ClusterThrottle.{Selector, SelectorItem}
 import com.github.everpeace.k8s.throttler.crd.v1alpha1.Implicits._
 import com.github.everpeace.k8s.throttler.crd.v1alpha1.{
   IsResourceAmountThrottled,
@@ -43,9 +44,13 @@ class ClusterThrottleFormatSpec extends FreeSpec with Matchers {
            |  "spec": {
            |    "throttlerName": "kube-throttler",
            |    "selector": {
-           |      "matchLabels": {
-           |        "key": "value"
-           |      }
+           |      "selectorTerms": [{
+           |        "podSelector": {
+           |          "matchLabels": {
+           |            "key": "value"
+           |          }
+           |        }
+           |      }]
            |    },
            |    "threshold": {
            |      "resourceCounts": {
@@ -88,7 +93,13 @@ class ClusterThrottleFormatSpec extends FreeSpec with Matchers {
           name = "app-throttle",
           spec = v1alpha1.ClusterThrottle.Spec(
             throttlerName = "kube-throttler",
-            selector = LabelSelector(IsEqualRequirement("key", "value")),
+            selector = Selector(
+              selectorTerms = List(
+                SelectorItem(
+                  podSelector = LabelSelector(IsEqualRequirement("key", "value")),
+                  namespaceSelector = None
+                )
+              )),
             threshold = ResourceAmount(
               resourceCounts = Option(
                 ResourceCount(

--- a/src/test/scala/com/github/everpeace/k8s/throttler/crd/ClusterThrottleSelectorSpec.scala
+++ b/src/test/scala/com/github/everpeace/k8s/throttler/crd/ClusterThrottleSelectorSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 Shingo Omura <https://github.com/everpeace>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.everpeace.k8s.throttler.crd
+import org.scalatest.{FreeSpec, Matchers}
+import skuber.{LabelSelector, Namespace, ObjectMeta, Pod}
+
+class ClusterThrottleSelectorSpec
+    extends FreeSpec
+    with Matchers
+    with v1alpha1.ClusterThrottle.Implicits {
+  def mkNs(name: String, labels: Map[String, String] = Map.empty) =
+    Namespace.from(
+      ObjectMeta(
+        name = name,
+        labels = labels
+      ))
+  def mkPod(namespace: String = "", name: String = "", labels: Map[String, String] = Map.empty) =
+    Pod
+      .named("")
+      .copy(
+        metadata = ObjectMeta(
+          namespace = namespace,
+          name = name,
+          labels = labels
+        )
+      )
+
+  "SelecterItem" - {
+    "maches(pod, namespace) should not match anything when pod and namespace are different" in {
+      val selectorItem = v1alpha1.ClusterThrottle.SelectorItem(
+        LabelSelector(LabelSelector.InRequirement("key1", List("value1"))),
+        Option(LabelSelector(LabelSelector.InRequirement("nskey1", List("nsvalue1"))))
+      )
+      val p1  = mkPod("default")
+      val ns1 = mkNs("different")
+      selectorItem.matches(p1, ns1) shouldBe false
+    }
+
+    "with podSelector and namespaceSelector should be evaluated in AND-ed" in {
+      val selectorItem = v1alpha1.ClusterThrottle.SelectorItem(
+        LabelSelector(LabelSelector.InRequirement("key1", List("value1"))),
+        Option(LabelSelector(LabelSelector.InRequirement("nskey1", List("nsvalue1"))))
+      )
+
+      val p1  = mkPod("default", "pod", Map("key1" -> "value1"))
+      val p2  = mkPod("default", "pod", Map("key2" -> "value2"))
+      val ns1 = mkNs(p1.namespace, Map("nskey1"    -> "nsvalue1"))
+      val ns2 = mkNs(p2.namespace, Map("nskey2"    -> "nsvalue2"))
+
+      selectorItem.matches(p1, ns1) shouldBe true
+      selectorItem.matches(p1, ns2) shouldBe false
+      selectorItem.matches(p2, ns1) shouldBe false
+      selectorItem.matches(p2, ns2) shouldBe false
+    }
+
+    "with empty namespaceSelector should be matched to all namespaces" in {
+      val selectorItem = v1alpha1.ClusterThrottle.SelectorItem(
+        LabelSelector(LabelSelector.InRequirement("key1", List("value1"))),
+        None
+      )
+      val p1  = mkPod("default", "pod", Map("key1" -> "value1"))
+      val p2  = mkPod("default2", "pod", Map("key1" -> "value1"))
+      val ns1 = mkNs(p1.namespace)
+      val ns2 = mkNs(p2.namespace)
+      selectorItem.matches(p1, ns1) shouldBe true
+      selectorItem.matches(p2, ns2) shouldBe true
+    }
+  }
+
+  "Selector" - {
+    "matches(pod, namespace) returns false when pod and namespace is different" in {
+      val p  = mkPod()
+      val ns = mkNs("ns1")
+      v1alpha1.ClusterThrottle.Selector(List.empty).matches(p, ns) shouldBe false
+    }
+    "with empty selecterTerms doesn't match anything" in {
+      val p  = mkPod()
+      val ns = mkNs(p.namespace)
+      v1alpha1.ClusterThrottle.Selector(List.empty).matches(p, ns) shouldBe false
+    }
+    "nonEmpty selecterTerms are evaluated in OR-ed" in {
+      val selector = v1alpha1.ClusterThrottle.Selector(
+        List(
+          v1alpha1.ClusterThrottle.SelectorItem(
+            LabelSelector(LabelSelector.InRequirement("key1", List("value1")))),
+          v1alpha1.ClusterThrottle.SelectorItem(
+            LabelSelector(LabelSelector.InRequirement("key2", List("value2")))),
+        ))
+
+      val p1 = mkPod("default", "pod", Map("key1" -> "value1"))
+      val p2 = mkPod("default", "pod", Map("key2" -> "value2"))
+      val p3 = mkPod("default", "pod", Map("key3" -> "value3"))
+      val ns = mkNs("default")
+
+      selector.matches(p1, ns) shouldBe true
+      selector.matches(p2, ns) shouldBe true
+      selector.matches(p3, ns) shouldBe false
+    }
+  }
+
+}

--- a/src/test/scala/com/github/everpeace/k8s/throttler/crd/ThrottleFormatSpec.scala
+++ b/src/test/scala/com/github/everpeace/k8s/throttler/crd/ThrottleFormatSpec.scala
@@ -17,6 +17,7 @@
 package com.github.everpeace.k8s.throttler.crd
 
 import com.github.everpeace.k8s.throttler.crd.v1alpha1.Implicits._
+import com.github.everpeace.k8s.throttler.crd.v1alpha1.Throttle.{Selector, SelectorItem}
 import com.github.everpeace.k8s.throttler.crd.v1alpha1.{
   IsResourceAmountThrottled,
   IsResourceCountThrottled,
@@ -44,9 +45,13 @@ class ThrottleFormatSpec extends FreeSpec with Matchers {
            |  "spec": {
            |    "throttlerName": "kube-throttler",
            |    "selector": {
-           |      "matchLabels": {
-           |        "key": "value"
-           |      }
+           |      "selectorTerms": [{
+           |        "podSelector": {
+           |          "matchLabels": {
+           |            "key": "value"
+           |          }
+           |        }
+           |      }]
            |    },
            |    "threshold": {
            |      "resourceCounts": {
@@ -89,7 +94,10 @@ class ThrottleFormatSpec extends FreeSpec with Matchers {
           name = "app-throttle",
           spec = v1alpha1.Throttle.Spec(
             throttlerName = "kube-throttler",
-            selector = LabelSelector(IsEqualRequirement("key", "value")),
+            selector = Selector(
+              selectorTerms = List(
+                SelectorItem(podSelector = LabelSelector(IsEqualRequirement("key", "value")))
+              )),
             threshold = ResourceAmount(
               resourceCounts = Option(
                 ResourceCount(

--- a/src/test/scala/com/github/everpeace/k8s/throttler/crd/ThrottleSelectorSpec.scala
+++ b/src/test/scala/com/github/everpeace/k8s/throttler/crd/ThrottleSelectorSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Shingo Omura <https://github.com/everpeace>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.everpeace.k8s.throttler.crd
+
+import org.scalatest.{FreeSpec, Matchers}
+import skuber.{LabelSelector, Namespace, ObjectMeta, Pod}
+
+class ThrottleSelectorSpec extends FreeSpec with Matchers with v1alpha1.Throttle.Implicits {
+  def mkNs(name: String, labels: Map[String, String] = Map.empty) =
+    Namespace.from(
+      ObjectMeta(
+        name = name,
+        labels = labels
+      ))
+  def mkPod(namespace: String = "", name: String = "", labels: Map[String, String] = Map.empty) =
+    Pod
+      .named("")
+      .copy(
+        metadata = ObjectMeta(
+          namespace = namespace,
+          name = name,
+          labels = labels
+        )
+      )
+
+  "Selector" - {
+    "with empty selecterTerms doesn't match anything" in {
+      v1alpha1.Throttle.Selector(List.empty).matches(mkPod()) shouldBe false
+    }
+
+    "with non empty selecterTerms are evaluated in OR-ed" in {
+      val selector = v1alpha1.Throttle.Selector(
+        List(
+          v1alpha1.Throttle.SelectorItem(
+            LabelSelector(LabelSelector.InRequirement("key1", List("value1")))),
+          v1alpha1.Throttle.SelectorItem(
+            LabelSelector(LabelSelector.InRequirement("key2", List("value2")))),
+        ))
+
+      val p1 = mkPod("", "", Map("key1" -> "value1"))
+      val p2 = mkPod("", "", Map("key2" -> "value2"))
+      val p3 = mkPod("", "", Map("key3" -> "value3"))
+
+      selector.matches(p1) shouldBe true
+      selector.matches(p2) shouldBe true
+      selector.matches(p3) shouldBe false
+    }
+  }
+
+}


### PR DESCRIPTION
This supports OR-ed label selector such that

```
keyX==valX OR keyY==valY
```

These are yaml example
```
# Throttle(it can select pods in the same namespace)
apiVersion: schedule.k8s.everpeace.github.com/v1alpha1
kind: Throttle
metadata:
  name: foo
spec:
  throttlerName: kube-throttler
  selector:
    selectorTerms:
    - podSelector:
        matchLabels:
          throttle: t1
..


# ClusterThrottle(it can select pods across multiple namespaces)
apiVersion: schedule.k8s.everpeace.github.com/v1alpha1
kind: ClusterThrottle
metadata:
  name: foo
spec:
  throttlerName: kube-throttler
  selector:
    selectorTerms:
    - namespaceSelector:
        matchLabels:
          throttle: 'true'
      podSelector:
        matchLabels:
          throttle: t1
...
```