### PR TITLE
support preemption extender at /preempt_if_not_throttled

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This creates:
         "urlPrefix": "http://extender.kube-throttler/",
         "filterVerb": "check_throttle",
         "prioritizeVerb": "",
-        "preemptVerb": "",
+        "preemptVerb": "preempt_if_not_throttled",
         "bindVerb": "",
         "weight": 1,
         "enableHttps": false,

--- a/example/my-scheduler.yaml
+++ b/example/my-scheduler.yaml
@@ -32,7 +32,7 @@ data:
         "urlPrefix": "http://kube-throttler.kube-throttler/",
         "filterVerb": "check_throttle",
         "prioritizeVerb": "",
-        "preemptVerb": "",
+        "preemptVerb": "preempt_if_not_throttled",
         "bindVerb": "",
         "weight": 1,
         "enableHttps": false,
@@ -63,7 +63,7 @@ spec:
           name: my-scheduler-config
       containers:
       - name: my-scheduler-ctr
-        image: gcr.io/google_containers/hyperkube:v1.11.1
+        image: gcr.io/google_containers/hyperkube:v1.12.1
         imagePullPolicy: IfNotPresent
         args:
         - kube-scheduler

--- a/src/main/scala/com/github/everpeace/k8s/throttler/Routes.scala
+++ b/src/main/scala/com/github/everpeace/k8s/throttler/Routes.scala
@@ -17,6 +17,9 @@
 package com.github.everpeace.k8s.throttler
 
 import akka.actor.{ActorRef, ActorSystem}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.headers.`Content-Type`
 import akka.http.scaladsl.server.Directives._
 import akka.pattern.ask
 import akka.stream.ActorMaterializer
@@ -70,7 +73,7 @@ class Routes(
   }
 
   def all =
-    readinessProbe(requestHandlerReady).toRoute ~ livenessProbe(controllerAlive).toRoute ~ checkThrottle
+    readinessProbe(requestHandlerReady).toRoute ~ livenessProbe(controllerAlive).toRoute ~ checkThrottle ~ preemptIfNotThrottled
 
   def errorResult(arg: ExtenderArgs, message: String): v1.ExtenderFilterResult = {
     val nodeNames = if (arg.nodes.nonEmpty) {
@@ -117,64 +120,118 @@ class Routes(
 
   def checkThrottle = path("check_throttle") {
     post {
-      entity(as[v1.ExtenderArgs]) { extenderArgs =>
-        val pod = extenderArgs.pod
-        system.log.info("checking throttle status for pod {}", pod.key)
-        onComplete(requestHandleActor ? CheckThrottleRequest(pod)) {
-          // some throttles are active!!  no nodes are schedulable
-          case Success(
-              Throttled(p,
-                        activeThrottles,
-                        activeClusterThrottles,
-                        noSpaceThrottles,
-                        noSpaceClusterThrottles)) if p == pod =>
-            val activeThrottleMessage = activeThrottles.toList.toNel
-              .map { thrs =>
-                val names = thrs.map(thr => thr.namespace -> thr.name).toList
-                s"throttles[active]=${names.mkString(",")}"
-              }
+      logRequestResult("preempt_if_not_throttled") {
+        entity(as[v1.ExtenderArgs]) { extenderArgs =>
+          val pod = extenderArgs.pod
+          system.log.info("checking throttle status for pod {}", pod.key)
+          onComplete((requestHandleActor ? CheckThrottleRequest(pod)).mapTo[CheckThrottleResponse]) {
+            // some throttles are active!!  no nodes are schedulable
+            case Success(
+                Throttled(p,
+                          activeThrottles,
+                          activeClusterThrottles,
+                          noSpaceThrottles,
+                          noSpaceClusterThrottles)) if p == pod =>
+              val activeThrottleMessage = activeThrottles.toList.toNel
+                .map { thrs =>
+                  val names = thrs.map(thr => thr.namespace -> thr.name).toList
+                  s"throttles[active]=${names.mkString(",")}"
+                }
 
-            val activeClusterThrottleMessage = activeClusterThrottles.toList.toNel
-              .map { thrs =>
-                val names = thrs.map(_.name).toList
-                s"clusterthrottles[active]=${names.mkString(",")}"
-              }
+              val activeClusterThrottleMessage = activeClusterThrottles.toList.toNel
+                .map { thrs =>
+                  val names = thrs.map(_.name).toList
+                  s"clusterthrottles[active]=${names.mkString(",")}"
+                }
 
-            val noSpaceThrottleMessage = noSpaceThrottles.toList.toNel
-              .map { thrs =>
-                val names = thrs.map(thr => thr.namespace -> thr.name).toList
-                s"throttles[insufficient]=${names.mkString(",")}"
-              }
+              val noSpaceThrottleMessage = noSpaceThrottles.toList.toNel
+                .map { thrs =>
+                  val names = thrs.map(thr => thr.namespace -> thr.name).toList
+                  s"throttles[insufficient]=${names.mkString(",")}"
+                }
 
-            val noSpaceClusterThrottleMessage = noSpaceClusterThrottles.toList.toNel
-              .map { thrs =>
-                val names = thrs.map(_.name).toList
-                s"clusterthrottles[insufficient]=${names.mkString(",")}"
-              }
+              val noSpaceClusterThrottleMessage = noSpaceClusterThrottles.toList.toNel
+                .map { thrs =>
+                  val names = thrs.map(_.name).toList
+                  s"clusterthrottles[insufficient]=${names.mkString(",")}"
+                }
 
-            val aggregatedMessage =
-              List(activeThrottleMessage,
-                   activeClusterThrottleMessage,
-                   noSpaceThrottleMessage,
-                   noSpaceClusterThrottleMessage).filter(_.nonEmpty).map(_.get).mkString(", ")
+              val aggregatedMessage =
+                List(activeThrottleMessage,
+                     activeClusterThrottleMessage,
+                     noSpaceThrottleMessage,
+                     noSpaceClusterThrottleMessage).filter(_.nonEmpty).map(_.get).mkString(", ")
 
-            val message = s"pod ${pod.key} is unschedulable due to $aggregatedMessage"
-            system.log.info(message)
-            complete(unSchedulableResult(extenderArgs, message))
+              val message = s"pod ${pod.key} is unschedulable due to $aggregatedMessage"
+              system.log.info(message)
+              complete(unSchedulableResult(extenderArgs, message))
 
-          // no throttles are active!!  all nodes are schedulable.
-          case Success(NotThrottled(p)) if p == pod =>
-            system.log.info(
-              "pod {} is schedulable because no 'throttled' throttles/clusterthrottles for the pod.",
-              pod.key)
-            complete(schedulableResult(extenderArgs))
+            // no throttles are active!!  all nodes are schedulable.
+            case Success(NotThrottled(p)) if p == pod =>
+              system.log.info(
+                "pod {} is schedulable because no 'throttled' throttles/clusterthrottles for the pod.",
+                pod.key)
+              complete(schedulableResult(extenderArgs))
 
-          // failure.  no nodes are schedulable.
-          case Failure(exp) =>
-            val message =
-              s"exception occurred in checking throttles for pod ${pod.key}: ${exp.getMessage}"
-            system.log.error(message)
-            complete(errorResult(extenderArgs, message))
+            case Success(NotReady) =>
+              val message = s"throttler is not ready in checking throttle status of pod ${pod.key}"
+              system.log.error(message)
+              complete(errorResult(extenderArgs, message))
+
+            // failure.  no nodes are schedulable.
+            case Failure(exp) =>
+              val message =
+                s"exception occurred in checking throttles for pod ${pod.key}: ${exp.getMessage}"
+              system.log.error(message)
+              complete(errorResult(extenderArgs, message))
+          }
+        }
+      }
+    }
+  }
+
+  val noVictims = v1.ExtenderPreemptionResult(Map.empty)
+  def echoedResult(args: v1.ExtenderPreemptionArgs): v1.ExtenderPreemptionResult =
+    v1.ExtenderPreemptionResult(
+      args.nodeNameToVictims.mapValues(
+        victims =>
+          v1.MetaVictims(
+            pods = victims.pods.map(p => v1.MetaPod(p.uid)),
+            numPDBViolations = victims.numPDBViolations
+        )))
+
+  def preemptIfNotThrottled = path("preempt_if_not_throttled") {
+    post {
+      logRequestResult("preempt_if_not_throttled") {
+        entity(as[v1.ExtenderPreemptionArgs]) { extenderArgs =>
+          val pod = extenderArgs.pod
+          system.log.info("checking throttle status of pod {} for preemption", pod.key)
+          onComplete((requestHandleActor ? CheckThrottleRequest(pod)).mapTo[CheckThrottleResponse]) {
+            case Success(Throttled(_, _, _, _, _)) =>
+              val message = s"pod ${pod.key} is throttled.  no victims should be selected."
+              system.log.info(message)
+              complete(noVictims)
+            case Success(NotThrottled(_)) =>
+              val result     = echoedResult(extenderArgs)
+              val numVictims = result.nodeNameToMetaVictims.mapValues(_.pods.length)
+              val message    = s"pod ${pod.key} is throttled.  echo victims: $numVictims"
+              system.log.info(message)
+              complete(result)
+            case Success(NotReady) =>
+              val message =
+                s"throttler is not ready in checking throttle status of pod ${pod.key} for preemption"
+              system.log.error(message)
+              complete(StatusCodes.InternalServerError,
+                       List(`Content-Type`(`application/json`)),
+                       "{}")
+            case Failure(exp) =>
+              val message =
+                s"exception occurred in checking throttles of pod ${pod.key} for preemption: ${exp.getMessage}"
+              system.log.error(message)
+              complete(StatusCodes.InternalServerError,
+                       List(`Content-Type`(`application/json`)),
+                       "{}")
+          }
         }
       }
     }

--- a/src/main/scala/com/github/everpeace/k8s/throttler/controller/ThrottleRequestHandler.scala
+++ b/src/main/scala/com/github/everpeace/k8s/throttler/controller/ThrottleRequestHandler.scala
@@ -161,15 +161,17 @@ object ThrottleRequestHandler {
   case object IsReady
 
   case class CheckThrottleRequest(pod: Pod)
-  case object NotReady
+  sealed trait CheckThrottleResponse
+  case object NotReady extends CheckThrottleResponse
   case class Throttled(
       pod: Pod,
       activeThrottles: Set[v1alpha1.Throttle],
       activeClusterThrottles: Set[v1alpha1.ClusterThrottle],
       insufficientThrottles: Set[v1alpha1.Throttle],
       insufficientClusterThrottles: Set[v1alpha1.ClusterThrottle])
+      extends CheckThrottleResponse
 
-  case class NotThrottled(pod: Pod)
+  case class NotThrottled(pod: Pod) extends CheckThrottleResponse
 
   def props() = Props(new ThrottleRequestHandler())
 }

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -1,0 +1,2 @@
+akka.loglevel = "DEBUG"
+

--- a/src/test/scala/io/k8s/pkg/scheduler/api/v1/ExtenderFormatSpec.scala
+++ b/src/test/scala/io/k8s/pkg/scheduler/api/v1/ExtenderFormatSpec.scala
@@ -39,6 +39,25 @@ class ExtenderFormatSpec extends FreeSpec with Matchers {
       Json.toJson(filterResultJson.validate[ExtenderFilterResult].get) shouldBe filterResultJson
     }
   }
+
+  "Format[ExtenderPreemptionArgs]" - {
+    "can unmarshal jsons without 'apiVersion' and 'kind'" in {
+      preemptArgJson.validate[ExtenderFilterResult].isSuccess shouldBe true
+    }
+    "can marshal ExtenderPreemptionArgs to json without 'apiVersion' and 'kind" in {
+      val v = preemptArgJson.validate[ExtenderPreemptionArgs]
+      Json.toJson(v.get) shouldBe preemptArgJson
+    }
+  }
+
+  "Format[ExtenderPreemptionResult]" - {
+    "can unmarshal jsons without 'apiVersion' and 'kind'" in {
+      preemptResultJson.validate[ExtenderFilterResult].isSuccess shouldBe true
+    }
+    "can marshal ExtenderPreemptionResult to json without 'apiVersion' and 'kind" in {
+      Json.toJson(preemptResultJson.validate[ExtenderPreemptionResult].get) shouldBe preemptResultJson
+    }
+  }
 }
 
 object ExtenderFormatSpec {
@@ -82,4 +101,45 @@ object ExtenderFormatSpec {
        |  "Error": "error"
        |}
        |""".stripMargin)
+
+  val preemptArgJson = Json.parse("""|{
+      |  "Pod": {
+      |    "metadata": {
+      |      "name": "pod-rzgq6",
+      |      "labels": {
+      |        "throttle": "t1"
+      |      }
+      |    }
+      |  },
+      |  "NodeNameToVictims": {
+      |    "node1": {
+      |      "Pods": [{
+      |        "metadata": {
+      |          "name": "pod-rzgq6",
+      |          "labels": {
+      |            "throttle": "t1"
+      |          }
+      |        }
+      |      }],
+      |      "NumPDBViolations": 0
+      |    }
+      |  },
+      |  "NodeNameToMetaVictims": {
+      |    "node1": {
+      |      "Pods": [{ "UID": "xxx" }],
+      |      "NumPDBViolations": 0
+      |    }
+      |  }
+      |}
+    """.stripMargin)
+
+  val preemptResultJson = Json.parse("""|{
+      |  "NodeNameToMetaVictims":{
+      |    "node1": {
+      |      "Pods": [{ "UID": "xxx" }],
+      |      "NumPDBViolations": 0
+      |    }
+      |  }
+      |}
+    """.stripMargin)
 }


### PR DESCRIPTION
When pod is throttled, kube-throttler returns `FitError` for all nodes in `Filter` scheduler extender.  However, when scheduler received `FitError`, it will try preemption.  kube-throttler must interact with preemption phase in order to stop preemption tries.