### PR TITLE
Fail fast liveness probe by stopping ThrottleController when kubernetes api watch stopped

### DIFF
--- a/src/main/scala/com/github/everpeace/k8s/throttler/KubeThrottler.scala
+++ b/src/main/scala/com/github/everpeace/k8s/throttler/KubeThrottler.scala
@@ -65,7 +65,7 @@ object KubeThrottler extends App {
   val throttler =
     system.actorOf(ThrottleController.props(requestHandleActor, k8s, config), "throttle-controller")
   val throttlerWatcher =
-    system.actorOf(ActorWatcher.props(requestHandleActor), name = "throttle-controller-watcher")
+    system.actorOf(ActorWatcher.props(throttler), name = "throttle-controller-watcher")
   val routes = new Routes(requestHandleActor,
                           throttlerWatcher,
                           config.throttlerAskTimeout,

--- a/src/main/scala/com/github/everpeace/k8s/throttler/Routes.scala
+++ b/src/main/scala/com/github/everpeace/k8s/throttler/Routes.scala
@@ -67,7 +67,7 @@ class Routes(
       if (isReady) {
         healthchecks.healthy
       } else {
-        healthchecks.unhealthy("throttle-controller is not ready.")
+        healthchecks.unhealthy("throttle-request-handler is not ready.")
       }
     }
   }

--- a/src/main/scala/com/github/everpeace/k8s/throttler/controller/ThrottleController.scala
+++ b/src/main/scala/com/github/everpeace/k8s/throttler/controller/ThrottleController.scala
@@ -190,7 +190,6 @@ class ThrottleController(
           lc
         )
         .map(PodWatchEvent(_))
-      // todo: use RestartSource to make the actor more stable.
       done <- {
         val fut = Source
           .combine(nsWatch, clthrottleWatch, throttleWatch, podWatch)(
@@ -656,15 +655,15 @@ class ThrottleController(
     case ResourceWatchDone(done) =>
       done match {
         case scala.util.Success(_) =>
-          log.error("watch api connection is closed.  restarting ThrottleController actor.")
-          throw new RuntimeException("watch api connection was closed.")
+          log.error("watch api connection is closed. committing suicide.")
+          self ! PoisonPill
         case scala.util.Failure(ex) =>
           log.error(
             "watch api connection was closed by an exceptions.  " +
-              "restarting ThrottleController actor. (cause = {})",
+              "committing suicide. (cause = {})",
             ex
           )
-          throw new RuntimeException(s"watch api failed by $ex.")
+          self ! PoisonPill
       }
   }
 

--- a/src/test/scala/com/github/everpeace/k8s/throttler/RoutesSpec.scala
+++ b/src/test/scala/com/github/everpeace/k8s/throttler/RoutesSpec.scala
@@ -18,7 +18,7 @@ package com.github.everpeace.k8s.throttler
 import akka.actor.{Actor, Props}
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import akka.testkit._
+import akka.testkit.TestDuration
 import akka.util.{ByteString, Timeout}
 import com.github.everpeace.k8s.throttler.controller.ThrottleRequestHandler.{
   CheckThrottleRequest,
@@ -29,8 +29,8 @@ import com.github.everpeace.k8s.throttler.crd.v1alpha1
 import com.github.everpeace.k8s.throttler.crd.v1alpha1.{IsResourceAmountThrottled, ResourceAmount}
 import com.github.everpeace.util.ActorWatcher
 import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport
-import io.k8s.pkg.scheduler.api.v1._
 import io.k8s.pkg.scheduler.api.v1.Implicits._
+import io.k8s.pkg.scheduler.api.v1._
 import org.scalatest.{FreeSpec, Matchers}
 import skuber.Resource.Quantity
 import skuber._
@@ -38,6 +38,8 @@ import skuber._
 import scala.concurrent.duration._
 
 class RoutesSpec extends FreeSpec with Matchers with ScalatestRouteTest with PlayJsonSupport {
+
+  implicit val timeout = RouteTestTimeout(3.seconds.dilated)
 
   def dummyActiveThrottleFor(p: Pod) = {
     v1alpha1
@@ -274,7 +276,6 @@ class RoutesSpec extends FreeSpec with Matchers with ScalatestRouteTest with Pla
                                   ByteString(requestBody)
                                 ))
 
-      implicit val timeout = RouteTestTimeout(3.seconds.dilated)
       val messageHead =
         """exception occurred in checking throttles for pod (default,timeout): Ask timed out on"""
 
@@ -401,7 +402,6 @@ class RoutesSpec extends FreeSpec with Matchers with ScalatestRouteTest with Pla
                                   MediaTypes.`application/json`,
                                   ByteString(requestBody)
                                 ))
-      implicit val timeout = RouteTestTimeout(3.seconds.dilated)
       request ~> throttlerRoutes ~> check {
         status shouldBe StatusCodes.InternalServerError
         responseAs[String] shouldBe "{}"


### PR DESCRIPTION
Currently, `RestartSource` retries kubernetes api watch internally.  This make is hard to find the watch restarting with unrecoverable failure like below in large cluster.

```
akka.stream.scaladsl.Framing$FramingException: JSON element exceeded maximumObjectLength (x00000 bytes)!
```

This PR changes ThrottleController to commit suicide and make this kubernetes liveness probe find this pod is not alive appropriately.