### PR TITLE
don't use apiclient directly in reconciller except for updating its status

### DIFF
--- a/pkg/controllers/clusterthrottle_controller.go
+++ b/pkg/controllers/clusterthrottle_controller.go
@@ -97,7 +97,7 @@ func (c *ClusterThrottleController) reconcile(key string) error {
 		return err
 	}
 
-	thr, err := c.scheduleClientset.ScheduleV1alpha1().ClusterThrottles().Get(ctx, name, metav1.GetOptions{})
+	thr, err := c.clusterthrottleInformer.Lister().Get(name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil

--- a/pkg/controllers/throttle_controller.go
+++ b/pkg/controllers/throttle_controller.go
@@ -94,7 +94,7 @@ func (c *ThrottleController) reconcile(key string) error {
 		return err
 	}
 
-	thr, err := c.scheduleClientset.ScheduleV1alpha1().Throttles(namespace).Get(ctx, name, metav1.GetOptions{})
+	thr, err := c.throttleInformer.Lister().Throttles(namespace).Get(name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil


### PR DESCRIPTION
because It will be throttled in large cluster.