### PR TITLE
Publish an pod event when the pod resource requests exceed throrttle's threshold for warning users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,4 +181,4 @@ e2e: fmt lint e2e-setup
 e2e-debug: fmt lint e2e-setup
 	GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT=$(E2E_GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT) \
 	GOMEGA_DEFAULT_CONSISTENTLY_DURATION=$(E2E_GOMEGA_DEFAULT_CONSISTENTLY_DURATION) \
-	dlv test --headless --listen=0.0.0.0:2345 --api-version=2 --log ./test/integration -- --kubeconfig=$(E2E_KIND_KUBECNOFIG)
+	dlv test --headless --listen=0.0.0.0:2345 --api-version=2 --log ./test/integration -- --kubeconfig=$(E2E_KIND_KUBECNOFIG) --pause-image=$(E2E_PAUSE_IMAGE)

--- a/test/integration/clusterthrottle_test.go
+++ b/test/integration/clusterthrottle_test.go
@@ -142,6 +142,25 @@ var _ = Describe("Clusterthrottle Test", func() {
 				Consistently(PodIsNotScheduled(ctx, DefaultNs, pod2.Name)).Should(Succeed())
 			})
 		})
+		Context("ResourceRequest (pod-requests-exceeds-threshold)", func() {
+			var pod *corev1.Pod
+			BeforeEach(func() {
+				pod = MustCreatePod(ctx, MakePod(DefaultNs, "pod", "1.1").Label(throttleKey, throttleName).Obj())
+			})
+			It("should not schedule pod", func() {
+				Eventually(AsyncAll(
+					WakeupBackoffPod(ctx),
+					ClusterThottleHasStatus(
+						ctx, thr.Name,
+						ClthrOpts.WithCalculatedThreshold(thr.Spec.Threshold),
+						ClthrOpts.WithPodThrottled(false), ClthrOpts.WithCpuThrottled(false),
+					),
+					MustPodFailedScheduling(ctx, DefaultNs, pod.Name, v1alpha1.CheckThrottleStatusPodRequestsExceedsThreshold),
+					MustPodResourceRequestsExceedsThrottleThreshold(ctx, DefaultNs, pod.Name, thr.Namespace+"/"+thr.Name),
+				)).Should(Succeed())
+				Consistently(PodIsNotScheduled(ctx, DefaultNs, pod.Name)).Should(Succeed())
+			})
+		})
 	})
 
 	When("Many pods are created at once", func() {

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -67,6 +67,7 @@ func TestIntegration(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	flag.Parse()
 	Expect(kubeConfigPath).NotTo(BeEmpty())
 	Expect(pauseImage).NotTo(BeEmpty())
 	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)


### PR DESCRIPTION
It is because the pod won't be scheduled unless throttle threshold will be increased.