### PR TITLE
fix: make reservedResourceAmounts fully goroutine-safe

### DIFF
--- a/pkg/controllers/reserved_resource_amounts.go
+++ b/pkg/controllers/reserved_resource_amounts.go
@@ -115,7 +115,10 @@ func (c *reservedResourceAmounts) reservedResourceAmount(nn types.NamespacedName
 	defer func() {
 		_ = c.keyMutex.UnlockKey(nn.String())
 	}()
+
+	c.RLock()
 	podResourceAmountMap, ok := c.cache[nn]
+	c.RUnlock()
 	if !ok {
 		return schedulev1alpha1.ResourceAmount{}, sets.New[string]()
 	}

--- a/pkg/controllers/reserved_resource_amounts_test.go
+++ b/pkg/controllers/reserved_resource_amounts_test.go
@@ -64,8 +64,20 @@ var _ = Describe("ReservedResourceAmounts", func() {
 				remove.Done()
 			}(i)
 		}
+
+		reservedResourceAmount := &sync.WaitGroup{}
+		reservedResourceAmount.Add(n)
+		for i := 0; i < n; i++ {
+			go func(j int) {
+				r.reservedResourceAmount(
+					types.NamespacedName{Name: "test"},
+				)
+				reservedResourceAmount.Done()
+			}(i)
+		}
 		add.Wait()
 		remove.Wait()
+		reservedResourceAmount.Wait()
 	})
 	It("should be threadsafe on specific throttle's namespacedname", func() {
 		r := newReservedResourceAmounts(1024)


### PR DESCRIPTION
In `reservedResourceAmount`, it didn't take any lock before accessing `c.cache` and it caused `concurrent map read and map write`.
We can reproduce it with the updated test in pkg/controllers/reserved_resource_amounts_test.go.